### PR TITLE
Add cwdbase option to enable file base to match cwd.

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,8 +50,9 @@ module.exports = us = {
     // create globbing stuff
     var globber = new glob.Glob(ourGlob, opt);
 
-    // extract base path because we are too lazy lol
-    var basePath = glob2base(globber);
+    // use cwd as base path if opt.cwdbase = true, otherwise extract 
+    // base path because we are too lazy lol
+    var basePath = opt.cwdbase ? opt.cwd : glob2base(globber);
 
     // create stream and map events from globber to it
     var stream = es.pause();

--- a/test/main.js
+++ b/test/main.js
@@ -124,6 +124,28 @@ describe('glob-stream', function() {
         done();
       });
     });
+    
+    it('should return a correctly ordered file name stream for two globs and custom base', function(done) {
+        var baseDir = join(__dirname, "./fixtures");
+        
+        var globArray = [
+          "./whatsgoingon/key/isaidhey/whatsgoingon/test.txt",
+          "./test.coffee",
+          "./whatsgoingon/test.js"
+        ];
+        var stream = gs.create(globArray, {cwd: baseDir, cwdbase: true});
+
+        var files = [];
+        stream.on('error', done);
+        stream.on('data', function(file) {
+          should.exist(file);
+          should.exist(file.base);
+          file.base.should.equal(baseDir);
+        });
+        stream.on('end', function() {
+          done();
+        });
+      });
 
     it('should return a input stream for multiple globs, with negation (globbing)', function(done) {
       var expectedPath = join(__dirname, "./fixtures/stuff/run.dmc");


### PR DESCRIPTION
By setting cwdbase: true, all files returned from glob will have a relative path being relative to the cwd. This is useful if you want perform operations on multiple directories relative to the cwd and not relative to the lowest glob expression.

Example:
gulp.src(["lib/**", "bin/**"], { cwd: process.cwd, cwdbase: true }).pipe(gulp.dest("/mydest/"));

This will result in /mydest/lib/<lib files> and /mydest/bin/<bin files> compared to /mydest/<lib and bin files>
