### PR TITLE
Added failing test and fix for #7. 

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@
 
 var through = require('through');
 var map = require('map-stream');
-var Combine = require('combine-stream');
+var Combine = require('ordered-read-streams');
 var unique = require('unique-stream');
 
 var glob = require('glob');

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "glob": "~3.2.7",
     "minimatch": "~0.2.12",
-    "combine-stream": "0.0.4",
+    "ordered-read-streams": "~0.0.3",
     "glob2base": "~0.0.4",
     "unique-stream": "~0.0.3",
     "through": "~2.3.4",

--- a/test/main.js
+++ b/test/main.js
@@ -212,6 +212,30 @@ describe('glob-stream', function() {
       });
     });
 
+    it('should return a correctly ordered file name stream for three globs with globstars', function(done) {
+      var globArray = [
+        join(__dirname, "./fixtures/**/test.txt"),
+        join(__dirname, "./fixtures/**/test.coffee"),
+        join(__dirname, "./fixtures/**/test.js")
+      ];
+      var stream = gs.create(globArray, {cwd: __dirname});
+
+      var files = [];
+      stream.on('error', done);
+      stream.on('data', function(file) {
+        should.exist(file);
+        should.exist(file.path);
+        files.push(file);
+      });
+      stream.on('end', function() {
+        files.length.should.equal(3);
+        path.basename(files[0].path).should.equal('test.txt');
+        path.basename(files[1].path).should.equal('test.coffee');
+        path.basename(files[2].path).should.equal('test.js');
+        done();
+      });
+    });
+
     it('should return a correctly ordered file name stream for two globs', function(done) {
       var globArray = [
         join(__dirname, "./fixtures/whatsgoingon/hey/isaidhey/whatsgoingon/test.txt"),


### PR DESCRIPTION
Replaced `combine-stream` dependency with `ordered-read-streams`. All globs are coming in order they passed in constructor.
