### PR TITLE
add a mention of `globby` in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ## Information
 
 <table>
-<tr> 
+<tr>
 <td>Package</td><td>glob-stream</td>
 </tr>
 <tr>
@@ -62,6 +62,11 @@ would not exclude any files, but this would
 ```js
 gulp.src(['*.js', '!b*.js'])
 ```
+
+#### Related
+
+- [globby](https://github.com/sindresorhus/globby) - Non-streaming `glob` wrapper with support for multiple patterns.
+
 
 [npm-url]: https://npmjs.org/package/glob-stream
 [npm-image]: https://badge.fury.io/js/glob-stream.png


### PR DESCRIPTION
`globby` mentions `glob-stream` in its readme: https://github.com/sindresorhus/globby/commit/781defe36d1515d145e3000437232db54e7bb6a7
