### PR TITLE
Implementing node-glob's `ignore` option, fixes #24

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,16 +66,17 @@ var gs = {
         throw new Error('Invalid glob at index ' + index);
       }
 
-      var globArray = isNegative(glob) ? negatives : positives;
+      var isNegativeGlob = isNegative(glob);
 
       // remove leading "!" from negative globs to pass them to glob's `ignore` option
-      if (globArray === negatives) {
+      if (isNegativeGlob) {
         glob = glob.slice(1);
       }
 
       // remove path relativity to make globs make sense
       glob = unrelative(opt.cwd, glob);
 
+      var globArray = isNegativeGlob ? negatives : positives;
       globArray.push({
         index: index,
         glob: glob

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "index.js"
   ],
   "dependencies": {
-    "glob": "^4.4.0",
+    "glob": "UltCombo/node-glob#fix-166",
     "glob2base": "^0.0.12",
     "lodash.clone": "^3.0.1",
     "ordered-read-streams": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -8,12 +8,12 @@
     "index.js"
   ],
   "dependencies": {
-    "glob": "^4.3.1",
-    "minimatch": "^2.0.1",
-    "ordered-read-streams": "^0.1.0",
+    "glob": "^4.4.0",
     "glob2base": "^0.0.12",
-    "unique-stream": "^2.0.2",
-    "through2": "^0.6.1"
+    "object-assign": "^2.0.0",
+    "ordered-read-streams": "^0.1.0",
+    "through2": "^0.6.1",
+    "unique-stream": "^2.0.2"
   },
   "devDependencies": {
     "coveralls": "^2.11.2",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "glob": "^4.4.0",
     "glob2base": "^0.0.12",
-    "object-assign": "^2.0.0",
+    "lodash.clone": "^3.0.1",
     "ordered-read-streams": "^0.1.0",
     "through2": "^0.6.1",
     "unique-stream": "^2.0.2"

--- a/test/main.js
+++ b/test/main.js
@@ -456,24 +456,6 @@ describe('glob-stream', function() {
       });
     });
 
-    it('should handle RegExps as negative matchers', function(done) {
-      var stream = gs.create(['./fixtures/stuff/*.dmc', /run/], {cwd: __dirname});
-      should.exist(stream);
-      stream.on('error', function(err) {
-        throw err;
-      });
-      stream.on('data', function(file) {
-        should.exist(file);
-        should.exist(file.path);
-        should.exist(file.base);
-        should.exist(file.cwd);
-        String(file.cwd).should.equal(__dirname);
-        String(file.base).should.equal(join(__dirname, 'fixtures', 'stuff'+sep));
-        String(join(file.path,'')).should.equal(join(__dirname, './fixtures/stuff/run.dmc'));
-        done();
-      });
-    });
-
     it('should throw on invalid glob argument', function() {
       gs.create.bind(gs, 42, {cwd: __dirname}).should.throw(/Invalid glob .* 0/);
       gs.create.bind(gs, ['.', 42], {cwd: __dirname}).should.throw(/Invalid glob .* 1/);


### PR DESCRIPTION
Quite a few tests are broken on my machine, not sure if I'm missing something or the `ignore` option is buggy in regard to the `dot` option and absolute paths (on Windows).

Fixes #24 