### PR TITLE
Fix for removal of trailing slashes

### DIFF
--- a/index.js
+++ b/index.js
@@ -187,7 +187,7 @@ function isAbsolutePath(p) {
     if (process.platform === 'win32') {
       return p[0] === '/' ||
              p[0] === '\\' ||
-             (p.length > 1 && p[1] === ':' && process.platform === 'win32');
+             (p.length > 1 && p[1] === ':');
     } else {
       return p[0] === '/';
     }

--- a/index.js
+++ b/index.js
@@ -44,7 +44,9 @@ var gs = {
       stream.write({
         cwd: opt.cwd,
         base: basePath,
-        path: restoreSlash(filename, path.resolve(opt.cwd, filename)),
+        path: path.isAbsolute(filename) ?
+          path.normalize(filename) :
+          path.normalize(opt.cwd + '/' + filename),
       });
     });
 
@@ -163,31 +165,19 @@ function isNegative(pattern) {
 }
 
 function resolveGlob(glob, opt) {
-  var originalGlob = glob;
   var mod = '';
   if (glob[0] === '!') {
     mod = glob[0];
     glob = glob.slice(1);
   }
   if (opt.root && glob[0] === '/') {
-    glob = path.resolve(opt.root, '.' + glob);
+    glob = path.normalize(opt.root + '/.' + glob);
   } else {
-    glob = path.resolve(opt.cwd, glob);
+    glob = path.isAbsolute(glob) ?
+      path.normalize(glob) :
+      path.normalize(opt.cwd + '/' + glob);
   }
-  return restoreSlash(originalGlob, mod + glob);
-}
-
-/*
- * Restores trailing slash that is removed from calls to path.resolve.
- */
-function restoreSlash(originalGlob, newGlob) {
-  if (newGlob === '/') {
-    return newGlob;
-  }
-  if (originalGlob[originalGlob.length - 1] === '/') {
-    return newGlob + '/';
-  }
-  return newGlob;
+  return mod + glob;
 }
 
 function indexGreaterThan(index) {

--- a/index.js
+++ b/index.js
@@ -40,11 +40,12 @@ var gs = {
     });
     globber.on('match', function(filename) {
       found = true;
+      var trailingSlash = (filename[filename.length - 1] === '/') ? '/' : '';
 
       stream.write({
         cwd: opt.cwd,
         base: basePath,
-        path: path.resolve(opt.cwd, filename),
+        path: path.resolve(opt.cwd, filename) + trailingSlash,
       });
     });
 
@@ -164,6 +165,7 @@ function isNegative(pattern) {
 
 function resolveGlob(glob, opt) {
   var mod = '';
+  var trailingSlash = (glob[glob.length - 1] === '/') ? '/' : '';
   if (glob[0] === '!') {
     mod = glob[0];
     glob = glob.slice(1);
@@ -173,7 +175,7 @@ function resolveGlob(glob, opt) {
   } else {
     glob = path.resolve(opt.cwd, glob);
   }
-  return mod + glob;
+  return mod + glob + trailingSlash;
 }
 
 function indexGreaterThan(index) {

--- a/index.js
+++ b/index.js
@@ -40,12 +40,11 @@ var gs = {
     });
     globber.on('match', function(filename) {
       found = true;
-      var trailingSlash = (filename[filename.length - 1] === '/') ? '/' : '';
 
       stream.write({
         cwd: opt.cwd,
         base: basePath,
-        path: path.resolve(opt.cwd, filename) + trailingSlash,
+        path: restoreSlash(filename, path.resolve(opt.cwd, filename)),
       });
     });
 
@@ -164,8 +163,8 @@ function isNegative(pattern) {
 }
 
 function resolveGlob(glob, opt) {
+  var originalGlob = glob;
   var mod = '';
-  var trailingSlash = (glob[glob.length - 1] === '/') ? '/' : '';
   if (glob[0] === '!') {
     mod = glob[0];
     glob = glob.slice(1);
@@ -175,7 +174,20 @@ function resolveGlob(glob, opt) {
   } else {
     glob = path.resolve(opt.cwd, glob);
   }
-  return mod + glob + trailingSlash;
+  return restoreSlash(originalGlob, mod + glob);
+}
+
+/*
+ * Restores trailing slash that is removed from calls to path.resolve.
+ */
+function restoreSlash(originalGlob, newGlob) {
+  if (newGlob === '/') {
+    return newGlob;
+  }
+  if (originalGlob[originalGlob.length - 1] === '/') {
+    return newGlob + '/';
+  }
+  return newGlob;
 }
 
 function indexGreaterThan(index) {

--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ var gs = {
       stream.write({
         cwd: opt.cwd,
         base: basePath,
-        path: path.isAbsolute(filename) ?
+        path: isAbsolutePath(filename) ?
           path.normalize(filename) :
           path.normalize(opt.cwd + '/' + filename),
       });
@@ -173,11 +173,25 @@ function resolveGlob(glob, opt) {
   if (opt.root && glob[0] === '/') {
     glob = path.normalize(opt.root + '/.' + glob);
   } else {
-    glob = path.isAbsolute(glob) ?
+    glob = isAbsolutePath(glob) ?
       path.normalize(glob) :
       path.normalize(opt.cwd + '/' + glob);
   }
   return mod + glob;
+}
+
+function isAbsolutePath(p) {
+  if (path.isAbsolute) {
+    return path.isAbsolute(p);
+  } else {
+    if (process.platform === 'win32') {
+      return p[0] === '/' ||
+             p[0] === '\\' ||
+             (p.length > 1 && p[1] === ':' && process.platform === 'win32');
+    } else {
+      return p[0] === '/';
+    }
+  }
 }
 
 function indexGreaterThan(index) {

--- a/test/main.js
+++ b/test/main.js
@@ -25,6 +25,24 @@ describe('glob-stream', function() {
       });
     });
 
+    it('should return only folder name stream from a glob', function(done) {
+      var folderCount = 0;
+      var stream = gs.create('./fixtures/whatsgoingon/*/', { cwd: __dirname });
+      stream.on('error', function(err) {
+        throw err;
+      });
+      stream.on('data', function(file) {
+        should.exist(file);
+        should.exist(file.path);
+        String(join(file.path, '')).should.equal(join(__dirname, './fixtures/whatsgoingon/hey/'));
+        folderCount++;
+      });
+      stream.on('end', function() {
+        folderCount.should.equal(1);
+        done();
+      });
+    });
+
     it('should return a file name stream from a glob', function(done) {
       var stream = gs.create('./fixtures/*.coffee', { cwd: __dirname });
       should.exist(stream);


### PR DESCRIPTION
The calls to the path.resolve function are stripping trailing slashes from glob patterns passed into the create function.  This is resulting in files coming back in search results when only folders should be for certain glob patterns.  

For example if I had the following folders and files:
/test/folder1/
/test/file1.js
/test/file2.js

And I passed in the following glob pattern:
/test/*/

I should only get back /test/folder1/ in the results, however because the trailing slash is removed and the pattern /test/* is applied I get back /test/folder1, /test/file1.js, and /test/file2.js in the results.

This pull request contains an update that restores the trailing slash when this scenario occurs so the expected results will be returned for glob patterns that target folders only.
