### PR TITLE
addresses absolute-glob issue 53

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ var unique = require('unique-stream');
 
 var glob = require('glob');
 var Minimatch = require('minimatch').Minimatch;
+var resolveGlob = require('to-absolute-glob');
 var glob2base = require('glob2base');
 var path = require('path');
 var extend = require('extend');
@@ -46,7 +47,7 @@ var gs = {
       stream.write({
         cwd: opt.cwd,
         base: basePath,
-        path: path.resolve(opt.cwd, filename),
+        path: filename,
       });
     });
 
@@ -163,20 +164,6 @@ function isNegative(pattern) {
   if (pattern instanceof RegExp) {
     return true;
   }
-}
-
-function resolveGlob(glob, opt) {
-  var mod = '';
-  if (glob[0] === '!') {
-    mod = glob[0];
-    glob = glob.slice(1);
-  }
-  if (opt.root && glob[0] === '/') {
-    glob = path.resolve(opt.root, '.' + glob);
-  } else {
-    glob = path.resolve(opt.cwd, glob);
-  }
-  return mod + glob;
 }
 
 function indexGreaterThan(index) {

--- a/package.json
+++ b/package.json
@@ -10,11 +10,12 @@
   "dependencies": {
     "extend": "^3.0.0",
     "glob": "^5.0.3",
+    "glob2base": "^0.0.12",
     "minimatch": "^2.0.1",
     "ordered-read-streams": "^0.3.0",
-    "glob2base": "^0.0.12",
-    "unique-stream": "^2.0.2",
-    "through2": "^0.6.0"
+    "through2": "^0.6.0",
+    "to-absolute-glob": "^0.1.1",
+    "unique-stream": "^2.0.2"
   },
   "devDependencies": {
     "coveralls": "^2.11.2",

--- a/test/main.js
+++ b/test/main.js
@@ -25,6 +25,24 @@ describe('glob-stream', function() {
       });
     });
 
+    it('should return only folder name stream from a glob', function(done) {
+      var folderCount = 0;
+      var stream = gs.create('./fixtures/whatsgoingon/*/', { cwd: __dirname });
+      stream.on('error', function(err) {
+        throw err;
+      });
+      stream.on('data', function(file) {
+        should.exist(file);
+        should.exist(file.path);
+        String(join(file.path, '')).should.equal(join(__dirname, './fixtures/whatsgoingon/hey/'));
+        folderCount++;
+      });
+      stream.on('end', function() {
+        folderCount.should.equal(1);
+        done();
+      });
+    });
+
     it('should return a file name stream from a glob', function(done) {
       var stream = gs.create('./fixtures/*.coffee', { cwd: __dirname });
       should.exist(stream);


### PR DESCRIPTION
This pr fixes the issue mentioned in #53. The code in the solution is based on code that is currently in glob-stream, and the solution was motivated by @natewallace and the problem he brought to light in #53.

fwiw I was tempted to also add checking for absolute paths, but since this fix works for every use case that is currently in the unit tests in glob-stream, as well as the test cases I could come up with for is-absolute-glob, IMHO it would be a better idea to use real feedback to drive any additional logic. 

last, if for some reason there is an unforeseen circumstance where the glob is already absolute and a `cwd` and/or `root` is passed on the options, then this solution might fail if `path.join` is used to combine the cwd/root and the glob. e.g. we'll end up with a duplicated absolute path. But... it seems like that would be the expected result, given that a cwd was passed. Anyway, just wanted to point this out so that if it happens we know what's happening and can fix it quickly..

(btw the dependencies in package.json were re-ordered automatically by npm, sorry about the extra cruft)