### PR TITLE
Use micromatch & glob-parent instead of minimatch & glob2base

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ You can pass any combination of globs. One caveat is that you can not only pass 
 - cwd
   - Default is `process.cwd()`
 - base
-  - Default is everything before a glob starts (see [glob2base](https://github.com/wearefractal/glob2base))
+  - Default is everything before a glob starts (see [glob-parent](https://github.com/es128/glob-parent))
 - cwdbase
   - Default is `false`
   - When true it is the same as saying opt.base = opt.cwd

--- a/index.js
+++ b/index.js
@@ -5,9 +5,9 @@ var Combine = require('ordered-read-streams');
 var unique = require('unique-stream');
 
 var glob = require('glob');
-var Minimatch = require('minimatch').Minimatch;
+var micromatch = require('micromatch');
 var resolveGlob = require('to-absolute-glob');
-var glob2base = require('glob2base');
+var globParent = require('glob-parent');
 var path = require('path');
 var extend = require('extend');
 
@@ -24,7 +24,7 @@ var gs = {
     var globber = new glob.Glob(ourGlob, ourOpt);
 
     // Extract base path from glob
-    var basePath = opt.base || glob2base(globber);
+    var basePath = opt.base || globParent(ourGlob) + '/';
 
     // Create stream and map events from globber to it
     var stream = through2.obj(opt,
@@ -108,7 +108,7 @@ var gs = {
       // Create Minimatch instances for negative glob patterns
       if (globArray === negatives && typeof glob === 'string') {
         var ourGlob = resolveGlob(glob, opt);
-        glob = new Minimatch(ourGlob, ourOpt);
+        glob = micromatch.matcher(ourGlob, ourOpt);
       }
 
       globArray.push({
@@ -149,8 +149,8 @@ var gs = {
 };
 
 function isMatch(file, matcher) {
-  if (matcher instanceof Minimatch) {
-    return matcher.match(file.path);
+  if (typeof matcher === 'function') {
+    return matcher(file.path);
   }
   if (matcher instanceof RegExp) {
     return matcher.test(file.path);

--- a/index.js
+++ b/index.js
@@ -8,7 +8,6 @@ var glob = require('glob');
 var micromatch = require('micromatch');
 var resolveGlob = require('to-absolute-glob');
 var globParent = require('glob-parent');
-var path = require('path');
 var extend = require('extend');
 
 var gs = {

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
   "dependencies": {
     "extend": "^3.0.0",
     "glob": "^5.0.3",
-    "glob2base": "^0.0.12",
-    "minimatch": "^2.0.1",
+    "glob-parent": "^2.0.0",
+    "micromatch": "^2.3.0",
     "ordered-read-streams": "^0.3.0",
     "through2": "^0.6.0",
     "to-absolute-glob": "^0.1.1",


### PR DESCRIPTION
Resolves #44

Let me know if you'd prefer I split this into two separate PRs

glob-parent v2 achieves parity with glob2base's handling of non-glob paths (stripping the filename) with a simpler algorithm and better performance. The only difference between them now is the trailing slash in the result, resolved simply enough here. I also added the patterns from the glob2base tests to the glob-parent repo to provide some extra assurance.

The caveat to swapping micromatch for minimatch here is that it only applies to negative globs. Positive globs are still just passed to node-glob, which of course continues to use micromatch. This does introduce an increased chance of new edge cases and inconsistencies which should be taken into consideration. But chokidar has been living with a similar inconsistency for a quite a while now (minimatch via readdirp for file tree walking and micromatch within chokidar for event filtering) and it hasn't been the source of any notable problems. (I also do have something in the works that will be able to replace node-glob and readdirp to resolve this, but that isn't an available solution for today)