### PR TITLE
use path.sep instead of '/' on Windows platform

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ var glob = require('glob');
 var micromatch = require('micromatch');
 var resolveGlob = require('to-absolute-glob');
 var globParent = require('glob-parent');
+var path = require('path');
 var extend = require('extend');
 
 var gs = {
@@ -23,7 +24,7 @@ var gs = {
     var globber = new glob.Glob(ourGlob, ourOpt);
 
     // Extract base path from glob
-    var basePath = opt.base || globParent(ourGlob) + '/';
+    var basePath = opt.base || globParent(ourGlob) + path.sep;
 
     // Create stream and map events from globber to it
     var stream = through2.obj(opt,


### PR DESCRIPTION
On Windows platform, `globParent(ourGlob) + '/'`generate bad path seperator. For example `\\glob-stream\\test\\fixtures\\stuff/`. Use `path.sep` instead to fix the issue.