### PR TITLE
Fix windows path

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ var gs = {
       stream.write({
         cwd: opt.cwd,
         base: basePath,
-        path: filename,
+        path: path.normalize(filename),
       });
     });
 


### PR DESCRIPTION
The only test case I can suggest is appveyor config. In result on windows `base` is backslashed but `path` is forwardslashed (node-glob way or something).