### PR TITLE
Resolve basePath first

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,13 +14,15 @@ var extend = require('extend');
 var gs = {
   // Creates a stream for a single glob or filter
   createStream: function(ourGlob, negatives, opt) {
+
+    var ourOpt = extend({}, opt);
+    delete ourOpt.root;
+
     // Extract base path from glob
-    var basePath = getBasePath(ourGlob, opt);
+    var basePath = ourOpt.base || getBasePath(ourGlob, opt);
 
     // Remove path relativity to make globs make sense
     ourGlob = resolveGlob(ourGlob, opt);
-    var ourOpt = extend({}, opt);
-    delete ourOpt.root;
 
     // Create globbing stuff
     var globber = new glob.Glob(ourGlob, ourOpt);
@@ -188,9 +190,6 @@ function globIsSingular(glob) {
 }
 
 function getBasePath(ourGlob, opt) {
-  if (opt.base) {
-    return opt.base;
-  }
   return resolveGlob(globParent(ourGlob) + path.sep, opt);
 }
 

--- a/index.js
+++ b/index.js
@@ -14,6 +14,8 @@ var extend = require('extend');
 var gs = {
   // Creates a stream for a single glob or filter
   createStream: function(ourGlob, negatives, opt) {
+    // Extract base path from glob
+    var basePath = getBasePath(ourGlob, opt);
 
     // Remove path relativity to make globs make sense
     ourGlob = resolveGlob(ourGlob, opt);
@@ -22,9 +24,6 @@ var gs = {
 
     // Create globbing stuff
     var globber = new glob.Glob(ourGlob, ourOpt);
-
-    // Extract base path from glob
-    var basePath = opt.base || globParent(ourGlob) + path.sep;
 
     // Create stream and map events from globber to it
     var stream = through2.obj(opt,
@@ -186,6 +185,13 @@ function globIsSingular(glob) {
   return globSet[0].every(function isString(value) {
     return typeof value === 'string';
   });
+}
+
+function getBasePath(ourGlob, opt) {
+  if (opt.base) {
+    return opt.base;
+  }
+  return resolveGlob(globParent(ourGlob) + path.sep, opt);
 }
 
 module.exports = gs;

--- a/test/fixtures/has (parens)/test.dmc
+++ b/test/fixtures/has (parens)/test.dmc
@@ -1,0 +1,1 @@
+this is a test

--- a/test/main.js
+++ b/test/main.js
@@ -80,6 +80,27 @@ describe('glob-stream', function() {
       });
     });
 
+    it('should find files in paths that contain ( )', function(done) {
+      var stream = gs.create('./fixtures/**/*.dmc', { cwd: __dirname });
+      var files = [];
+      stream.on('error', done);
+      stream.on('data', function(file) {
+        should.exist(file);
+        should.exist(file.path);
+        files.push(file);
+      });
+      stream.on('end', function() {
+        files.length.should.equal(3);
+        path.basename(files[0].path).should.equal('test.dmc');
+        files[0].path.should.equal(join(__dirname, 'fixtures/has (parens)/test.dmc'));
+        path.basename(files[1].path).should.equal('run.dmc');
+        files[1].path.should.equal(join(__dirname, 'fixtures/stuff/run.dmc'));
+        path.basename(files[2].path).should.equal('test.dmc');
+        files[2].path.should.equal(join(__dirname, 'fixtures/stuff/test.dmc'));
+        done();
+      });
+    });
+
     it('should return a file name stream from a glob and respect state', function(done) {
       var stream = gs.create('./fixtures/stuff/*.dmc', { cwd: __dirname });
       var wrapper = stream.pipe(through2.obj(function(data, enc, cb) {
@@ -293,6 +314,7 @@ describe('glob-stream', function() {
         join(__dirname, './fixtures/**/test.txt'),
         join(__dirname, './fixtures/**/test.coffee'),
         join(__dirname, './fixtures/**/test.js'),
+        join(__dirname, './fixtures/**/test.dmc'),
       ];
       var stream = gs.create(globArray, { cwd: __dirname });
 
@@ -304,10 +326,12 @@ describe('glob-stream', function() {
         files.push(file);
       });
       stream.on('end', function() {
-        files.length.should.equal(3);
+        files.length.should.equal(5);
         path.basename(files[0].path).should.equal('test.txt');
         path.basename(files[1].path).should.equal('test.coffee');
         path.basename(files[2].path).should.equal('test.js');
+        path.basename(files[3].path).should.equal('test.dmc');
+        path.basename(files[4].path).should.equal('test.dmc');
         done();
       });
     });

--- a/test/main.js
+++ b/test/main.js
@@ -61,6 +61,25 @@ describe('glob-stream', function() {
       });
     });
 
+    it('should handle ( ) in directory paths', function(done) {
+      var cwd = join(__dirname, './fixtures/has (parens)');
+      var stream = gs.create('*.dmc', { cwd: cwd });
+      should.exist(stream);
+      stream.on('error', function(err) {
+        throw err;
+      });
+      stream.on('data', function(file) {
+        should.exist(file);
+        should.exist(file.path);
+        should.exist(file.base);
+        should.exist(file.cwd);
+        String(file.cwd).should.equal(cwd);
+        String(file.base).should.equal(cwd + sep);
+        String(join(file.path,'')).should.equal(join(cwd, 'test.dmc'));
+        done();
+      });
+    });
+
     it('should return a file name stream from a glob and respect state', function(done) {
       var stream = gs.create('./fixtures/stuff/*.dmc', { cwd: __dirname });
       var wrapper = stream.pipe(through2.obj(function(data, enc, cb) {


### PR DESCRIPTION
This PR resolves the `basePath` before expanding the glob into an absolute path. This is necessary for when paths contain "glob like" characters but aren't part of the actual glob pattern.

I wanted to get this up here for review. I'll be able to add a test for the specific gulp issue later today.