### PR TITLE
Windows path separator 

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,27 @@
+# Test against these versions of Node.js
+environment:
+  matrix:
+    # node.js
+    - nodejs_version: "6.0"
+    - nodejs_version: "5.0"
+    - nodejs_version: "4.0"
+    - nodejs_version: "0.12"
+    - nodejs_version: "0.10"
+
+# Install scripts. (runs after repo cloning)
+install:
+  # Get the latest stable version of Node.js or io.js
+  - ps: Install-Product node $env:nodejs_version
+  # install modules
+  - npm install
+
+# Post-install test scripts.
+test_script:
+  # Output useful info for debugging.
+  - node --version
+  - npm --version
+  # run tests
+  - npm test
+
+# Don't actually build.
+build: off

--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ var resolveGlob = require('to-absolute-glob');
 var globParent = require('glob-parent');
 var path = require('path');
 var extend = require('extend');
+var sepRe = (process.platform === 'win32' ? /[\/\\]/ : /\/+/);
 
 var gs = {
   // Creates a stream for a single glob or filter
@@ -190,7 +191,19 @@ function globIsSingular(glob) {
 }
 
 function getBasePath(ourGlob, opt) {
-  return resolveGlob(globParent(ourGlob) + path.sep, opt);
+  var basePath;
+  var parent = globParent(ourGlob);
+
+  if (parent === '/' && opt && opt.root) {
+    basePath = path.join(opt.root);
+  } else {
+    basePath = resolveGlob(parent, opt);
+  }
+
+  if (!sepRe.test(basePath.charAt(basePath.length - 1))) {
+    basePath += path.sep;
+  }
+  return basePath;
 }
 
 module.exports = gs;

--- a/index.js
+++ b/index.js
@@ -195,7 +195,7 @@ function getBasePath(ourGlob, opt) {
   var parent = globParent(ourGlob);
 
   if (parent === '/' && opt && opt.root) {
-    basePath = path.join(opt.root);
+    basePath = path.normalize(opt.root);
   } else {
     basePath = resolveGlob(parent, opt);
   }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "index.js"
   ],
   "scripts": {
-    "lint": "eslint . && jscs *.js test/",
+    "lint": "eslint . && jscs . test/",
     "pretest": "npm run lint",
     "test": "mocha",
     "coveralls": "istanbul cover _mocha --report lcovonly && istanbul-coveralls"


### PR DESCRIPTION
This PR includes the following changes:

- Add appveyor configuration file
- Use `.` pattern for jscs for windows.
- Handle windows path separators when calculating base path on windows.

This fixes #68 