### PR TITLE
Breaking: Remove path normalization (closes #79)

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,12 +6,11 @@ var unique = require('unique-stream');
 
 var glob = require('glob');
 var pumpify = require('pumpify');
-var resolveGlob = require('to-absolute-glob');
 var isNegatedGlob = require('is-negated-glob');
 var globParent = require('glob-parent');
-var path = require('path');
+var resolveGlob = require('to-absolute-glob');
 var extend = require('extend');
-var sepRe = (process.platform === 'win32' ? /[\/\\]/ : /\/+/);
+var removeTrailingSeparator = require('remove-trailing-separator');
 
 function globStream(globs, opt) {
   if (!opt) {
@@ -137,7 +136,7 @@ function createStream(ourGlob, negatives, opt) {
     stream.write({
       cwd: opt.cwd,
       base: basePath,
-      path: path.normalize(filename),
+      path: removeTrailingSeparator(filename),
     });
   });
   return stream;
@@ -165,19 +164,7 @@ function globIsSingular(glob) {
 }
 
 function getBasePath(ourGlob, opt) {
-  var basePath;
-  var parent = globParent(ourGlob);
-
-  if (parent === '/' && opt && opt.root) {
-    basePath = path.normalize(opt.root);
-  } else {
-    basePath = resolveGlob(parent, opt);
-  }
-
-  if (!sepRe.test(basePath.charAt(basePath.length - 1))) {
-    basePath += path.sep;
-  }
-  return basePath;
+  return globParent(resolveGlob(ourGlob, opt));
 }
 
 module.exports = globStream;

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "extend": "^3.0.0",
     "glob": "^7.1.1",
-    "glob-parent": "^3.0.0",
+    "glob-parent": "^3.1.0",
     "is-negated-glob": "^1.0.0",
     "ordered-read-streams": "^0.3.0",
     "pumpify": "^1.3.5",

--- a/package.json
+++ b/package.json
@@ -22,13 +22,14 @@
   },
   "dependencies": {
     "extend": "^3.0.0",
-    "glob": "^7.0.6",
+    "glob": "^7.1.1",
     "glob-parent": "^3.0.0",
     "is-negated-glob": "^1.0.0",
     "ordered-read-streams": "^0.3.0",
     "pumpify": "^1.3.5",
+    "remove-trailing-separator": "^1.0.1",
     "through2": "^0.6.0",
-    "to-absolute-glob": "^0.1.1",
+    "to-absolute-glob": "^2.0.0",
     "unique-stream": "^2.0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
@contra @jonschlinkert @doowb @es128 if any of you are able to review this, I'd appreciate it.

Originally this PR was going to try to remove some dependencies by using an option I added to node-glob (`absolute`); however, it was breaking in some subtle ways and I couldn't get my PRs accepted to fix them.  That being said, I was still able to streamline this module and remove the fact that we were converting glob paths to Windows-style paths by using `path.normalize`.