### PR TITLE
Update node-glob to grab security audit fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "extend": "^3.0.0",
-    "glob": "^7.1.1",
+    "glob": "^7.1.3",
     "glob-parent": "^3.1.0",
     "is-negated-glob": "^1.0.0",
     "ordered-read-streams": "^1.0.0",


### PR DESCRIPTION
`7.1.2` introduced security fixes (found via `npm audit`) and is now up to version `7.1.3` and should be updated