### PR TITLE
Set up Dependabot for npm dependencies 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+- package-ecosystem: npm
+  open-pull-requests-limit: 30
+  directory: /
+  schedule:
+    interval: weekly
+- package-ecosystem: github-actions
+  directory: /
+  schedule:
+    interval: weekly

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,3 @@ updates:
   directory: /
   schedule:
     interval: weekly
-- package-ecosystem: github-actions
-  directory: /
-  schedule:
-    interval: weekly


### PR DESCRIPTION
This will help keep dependencies up-to-date.
At least glob-parent requires to be updated to at least 5.1.2 to avoid security issues 