### PR TITLE
Update glob-parent version to 5.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "extend": "^3.0.0",
     "glob": "^7.1.1",
-    "glob-parent": "^3.1.0",
+    "glob-parent": "^5.1.2",
     "is-negated-glob": "^1.0.0",
     "ordered-read-streams": "^1.0.0",
     "pumpify": "^1.3.5",


### PR DESCRIPTION
This update goal to fix a security vulnerability.

In older versions before 5.1.2 of glob-parent, there are "Regular expression denial of service".
5.1.2 version of glob-parent fix that.