### PR TITLE
OS independent square brackets []

### DIFF
--- a/readable.js
+++ b/readable.js
@@ -82,6 +82,13 @@ function GlobStream(ourGlob, negatives, opt) {
   // Delete `root` after all resolving done
   delete ourOpt.root;
 
+  if (process.platform === 'win32') {
+    // Make glob use windows bracket escaping
+    ourGlob = ourGlob.replace(/\\\[(.*?)\\\]/g, '[[]$1]');
+    // Delete backslash escaping for bracktes in cwd as it isn't needed
+    ourOpt.cwd = ourOpt.cwd.replace(/\\\[(.*?)\\\]/g, '[$1]');
+  }
+
   var globber = new glob.Glob(ourGlob, ourOpt);
   this._globber = globber;
 

--- a/test/fixtures/has [brackets]/test.dmc
+++ b/test/fixtures/has [brackets]/test.dmc
@@ -1,0 +1,1 @@
+this is a test

--- a/test/index.js
+++ b/test/index.js
@@ -126,12 +126,17 @@ describe('glob-stream', function () {
     );
   });
 
-  it('finds files in paths that contain ( ) when they match the glob', function (done) {
+  it('finds files in paths that contain ( ) or [ ] when they match the glob', function (done) {
     var expected = [
       {
         cwd: dir,
         base: dir + '/fixtures',
         path: dir + '/fixtures/has (parens)/test.dmc',
+      },
+      {
+        cwd: dir,
+        base: dir + '/fixtures',
+        path: dir + '/fixtures/has [brackets]/test.dmc',
       },
       {
         cwd: dir,
@@ -146,14 +151,53 @@ describe('glob-stream', function () {
     ];
 
     function assert(pathObjs) {
-      expect(pathObjs.length).toEqual(3);
+      expect(pathObjs.length).toEqual(4);
       expect(pathObjs).toContainEqual(expected[0]);
       expect(pathObjs).toContainEqual(expected[1]);
       expect(pathObjs).toContainEqual(expected[2]);
+      expect(pathObjs).toContainEqual(expected[3]);
     }
 
     pipe(
       [globStream('./fixtures/**/*.dmc', { cwd: dir }), concat(assert)],
+      done
+    );
+  });
+
+  it('properly handles [ ] in cwd path', function (done) {
+    var cwd = dir + '/fixtures/has [brackets]';
+
+    var expected = {
+      cwd: cwd,
+      base: cwd,
+      path: cwd + '/test.dmc',
+    };
+
+    function assert(pathObjs) {
+      expect(pathObjs.length).toEqual(1);
+      expect(pathObjs[0]).toEqual(expected);
+    }
+
+    pipe([globStream('*.dmc', { cwd: cwd }), concat(assert)], done);
+  });
+
+  it('sets the correct base when [ ] in glob', function (done) {
+    var expected = {
+      cwd: dir,
+      base: dir + '/fixtures/has [brackets]',
+      path: dir + '/fixtures/has [brackets]/test.dmc',
+    };
+
+    function assert(pathObjs) {
+      expect(pathObjs.length).toEqual(1);
+      expect(pathObjs[0]).toEqual(expected);
+    }
+
+    pipe(
+      [
+        globStream('./fixtures/has \\[brackets\\]/*.dmc', { cwd: dir }),
+        concat(assert),
+      ],
       done
     );
   });
@@ -282,6 +326,11 @@ describe('glob-stream', function () {
       {
         cwd: dir,
         base: dir + '/fixtures',
+        path: dir + '/fixtures/has [brackets]/test.dmc',
+      },
+      {
+        cwd: dir,
+        base: dir + '/fixtures',
         path: dir + '/fixtures/stuff/test.dmc',
       },
     ];
@@ -294,7 +343,7 @@ describe('glob-stream', function () {
     ];
 
     function assert(pathObjs) {
-      expect(pathObjs.length).toEqual(5);
+      expect(pathObjs.length).toEqual(6);
       expect(pathObjs).toEqual(expected);
     }
 

--- a/test/readable.js
+++ b/test/readable.js
@@ -98,7 +98,7 @@ describe('readable stream', function () {
     ];
 
     function assert(pathObjs) {
-      expect(pathObjs.length).toBe(3);
+      expect(pathObjs.length).toBe(4);
       expect(pathObjs).toContainEqual(expected[0]);
       expect(pathObjs).toContainEqual(expected[1]);
       expect(pathObjs).toContainEqual(expected[2]);
@@ -122,8 +122,8 @@ describe('readable stream', function () {
     }
 
     function assert(pathObjs) {
-      expect(pathObjs.length).toEqual(3);
-      expect(spy.callCount).toEqual(2);
+      expect(pathObjs.length).toEqual(4);
+      expect(spy.callCount).toEqual(3);
       sinon.restore();
     }
 


### PR DESCRIPTION
In [#2346](https://github.com/gulpjs/gulp/issues/2436) @iliyahanev explained that globs weren't working properly on different platforms, be it win32 and Linux. I took the task at hand and solved it in the best way possible, because it may not adhere to the coding standards of gulpjs I will explain the problem here. If you pass a non escaped bracket to glob-stream in the cwd this will not work as `node-glob` (`picomatch`) will do weird stuff with it and not really do what you want to do, but if you do escape it (with backslash) `to-absolute-glob` will think "unixify" it (aka converting \ to /) so that also breaks. Then there is another problem, windows escapes brackets with the syntax `[[]myfilename]` but then most other systems use `\[myfilename\]` for escaping brackets. To solve all of this first before passing cwds to `to-absolute-glob` I made sure that the cwd was unescaped (because if we don't do that we could escape it twice since we call `getBasePath` with the escaped cwd) and then escapped it again (and retrofitted only the `cwd` back to the glob, without touching the expression itself). That fixes our escaping and no escaping problem with `to-absolute-glob` but then we also need to escape specifically for windows, since we alredy have escaped brackets we can simply change the escaping (or remove it) to match windows requirements.