### PR TITLE
chore!: Drop support for ordered globs

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,18 +74,9 @@ function globStream(globs, opt) {
   return pumpify.obj(aggregate, uniqueStream);
 
   function streamFromPositive(positive) {
-    var negativeGlobs = negatives
-      .filter(indexGreaterThan(positive.index))
-      .map(toGlob)
-      .concat(ignore);
+    var negativeGlobs = negatives.map(toGlob).concat(ignore);
     return new GlobStream(positive.glob, negativeGlobs, ourOpt);
   }
-}
-
-function indexGreaterThan(index) {
-  return function (obj) {
-    return obj.index > index;
-  };
 }
 
 function toGlob(obj) {

--- a/index.js
+++ b/index.js
@@ -54,10 +54,7 @@ function globStream(globs, opt) {
     var glob = isNegatedGlob(globString);
     var globArray = glob.negated ? negatives : positives;
 
-    globArray.push({
-      index: index,
-      glob: glob.pattern,
-    });
+    globArray.push(glob.pattern);
   }
 
   if (positives.length === 0) {
@@ -74,13 +71,9 @@ function globStream(globs, opt) {
   return pumpify.obj(aggregate, uniqueStream);
 
   function streamFromPositive(positive) {
-    var negativeGlobs = negatives.map(toGlob).concat(ignore);
-    return new GlobStream(positive.glob, negativeGlobs, ourOpt);
+    var negativeGlobs = negatives.concat(ignore);
+    return new GlobStream(positive, negativeGlobs, ourOpt);
   }
-}
-
-function toGlob(obj) {
-  return obj.glob;
 }
 
 module.exports = globStream;

--- a/test/index.js
+++ b/test/index.js
@@ -548,39 +548,15 @@ describe('glob-stream', function () {
     );
   });
 
-  it('respects order of negative globs', function (done) {
-    var expected = {
-      cwd: dir,
-      base: dir + '/fixtures/stuff',
-      path: dir + '/fixtures/stuff/run.dmc',
-    };
-
+  it('applies all negative globs to each positive glob', function (done) {
     var globs = [
       './fixtures/stuff/*',
       '!./fixtures/stuff/*.dmc',
-      './fixtures/stuff/run.dmc',
+      './fixtures/stuff/*.dmc',
     ];
 
     function assert(pathObjs) {
-      expect(pathObjs.length).toEqual(1);
-      expect(pathObjs[0]).toEqual(expected);
-    }
-
-    pipe([globStream(globs, { cwd: dir }), concat(assert)], done);
-  });
-
-  it('ignores leading negative globs', function (done) {
-    var expected = {
-      cwd: dir,
-      base: dir + '/fixtures/stuff',
-      path: dir + '/fixtures/stuff/run.dmc',
-    };
-
-    var globs = ['!./fixtures/stuff/*.dmc', './fixtures/stuff/run.dmc'];
-
-    function assert(pathObjs) {
-      expect(pathObjs.length).toEqual(1);
-      expect(pathObjs[0]).toEqual(expected);
+      expect(pathObjs.length).toEqual(0);
     }
 
     pipe([globStream(globs, { cwd: dir }), concat(assert)], done);


### PR DESCRIPTION
With this change, glob-stream will no longer support ordered negation (each negative glob will apply to every positive glob). This is a large departure from gulp semantics, but I think it is better to align all our globbing and require users to combine `src` streams with `ordered-read-stream` if they need this.

This sets us up for replacing node-glob with anymatch to align with chokidar globbing.

In a future PR, I'll be streamlining the positive globs so they aren't applied in order either.