### PR TITLE
fix: Properly handle glob-like characters in paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "pumpify": "^2.0.1",
     "readable-stream": "^3.6.0",
     "remove-trailing-separator": "^1.1.0",
-    "to-absolute-glob": "^2.0.2",
+    "to-absolute-glob": "^3.0.0",
     "unique-stream": "^2.3.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test": "nyc mocha --async-only"
   },
   "dependencies": {
-    "glob": "^7.2.0",
+    "glob": "^8.0.3",
     "glob-parent": "^6.0.2",
     "is-negated-glob": "^1.0.0",
     "ordered-read-streams": "^1.0.1",

--- a/test/fixtures/has [brackets]/test.foo
+++ b/test/fixtures/has [brackets]/test.foo
@@ -1,0 +1,1 @@
+this is a test

--- a/test/index.js
+++ b/test/index.js
@@ -126,7 +126,7 @@ describe('glob-stream', function () {
     );
   });
 
-  it('finds files in paths that contain ( ) when they match the glob', function (done) {
+  it('finds files in paths that contain ( ) or [ ] when they match the glob', function (done) {
     var expected = [
       {
         cwd: dir,
@@ -136,24 +136,53 @@ describe('glob-stream', function () {
       {
         cwd: dir,
         base: dir + '/fixtures',
-        path: dir + '/fixtures/stuff/run.dmc',
-      },
-      {
-        cwd: dir,
-        base: dir + '/fixtures',
-        path: dir + '/fixtures/stuff/test.dmc',
+        path: dir + '/fixtures/has [brackets]/test.foo',
       },
     ];
 
     function assert(pathObjs) {
-      expect(pathObjs.length).toEqual(3);
+      expect(pathObjs.length).toEqual(2);
       expect(pathObjs).toContainEqual(expected[0]);
       expect(pathObjs).toContainEqual(expected[1]);
-      expect(pathObjs).toContainEqual(expected[2]);
+    }
+
+    pipe([globStream('./fixtures/has*/*', { cwd: dir }), concat(assert)], done);
+  });
+
+  it('properly handles [ ] in cwd path', function (done) {
+    var cwd = dir + '/fixtures/has [brackets]';
+
+    var expected = {
+      cwd: cwd,
+      base: cwd,
+      path: cwd + '/test.foo',
+    };
+
+    function assert(pathObjs) {
+      expect(pathObjs.length).toEqual(1);
+      expect(pathObjs[0]).toEqual(expected);
+    }
+
+    pipe([globStream('*.foo', { cwd: cwd }), concat(assert)], done);
+  });
+
+  it('sets the correct base when [ ] in glob', function (done) {
+    var expected = {
+      cwd: dir,
+      base: dir + '/fixtures/has [brackets]',
+      path: dir + '/fixtures/has [brackets]/test.foo',
+    };
+
+    function assert(pathObjs) {
+      expect(pathObjs.length).toEqual(1);
+      expect(pathObjs[0]).toEqual(expected);
     }
 
     pipe(
-      [globStream('./fixtures/**/*.dmc', { cwd: dir }), concat(assert)],
+      [
+        globStream('./fixtures/has \\[brackets\\]/*.foo', { cwd: dir }),
+        concat(assert),
+      ],
       done
     );
   });


### PR DESCRIPTION
See @pwall2222's excellent breakdown in #113 - this PR was recreated because I couldn't push my updates specified near the end.