### PR TITLE
fix: Avoid pushing additional paths to queue when error occurs

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "is-glob": "^4.0.3",
     "is-negated-glob": "^1.0.0",
     "normalize-path": "^3.0.0",
+    "now-and-later": "^3.0.0",
     "streamx": "^2.12.5"
   },
   "devDependencies": {


### PR DESCRIPTION
As mentioned at https://github.com/gulpjs/glob-stream/pull/122#discussion_r1535802638, @joshhunt pointed out that additional paths would be pushed to the queue if a symlink error occurred.

Here, I've pulled in our `now-and-later` dependency to iterate over the `dirents` with an iterator that handle async operations. This allows us to avoid pushing more items into the queue if an error occurs in the symlink resolution.

I couldn't find a good way to write a unit test for this because we don't expose the walker and the stream won't emit more `data` events after it has been destroyed. However, I did verify the behavior using `console.log` statements and adding a file named `z-test.txt` to the symlink directory.