### PR TITLE
fix: Only traverse directories that can match the glob base

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Run tests
         run: npm test
         env:
-          TMPDIR: ${{ runner.temp }}
+          TEMP: ${{ runner.temp }}
 
       - name: Coveralls
         uses: coverallsapp/github-action@v1.1.2

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -54,6 +54,8 @@ jobs:
 
       - name: Run tests
         run: npm test
+        env:
+          TMPDIR: ${{ runner.temp }}
 
       - name: Coveralls
         uses: coverallsapp/github-action@v1.1.2

--- a/test/index.js
+++ b/test/index.js
@@ -374,6 +374,8 @@ function suite(moduleName) {
       var testFile = path.join(os.tmpdir(), "glob-stream-test.txt");
       fs.writeFileSync(testFile, "test");
 
+      var tmp = deWindows(os.tmpdir());
+
       var expected = [
         {
           cwd: cwd,
@@ -393,8 +395,8 @@ function suite(moduleName) {
         },
         {
           cwd: cwd,
-          base: deWindows(os.tmpdir()),
-          path: deWindows(os.tmpdir()) + '/glob-stream-test.txt',
+          base: tmp,
+          path: tmp + '/glob-stream-test.txt',
         }
       ];
 
@@ -402,7 +404,7 @@ function suite(moduleName) {
         dir + '/fixtures/whatsgoingon/hey/isaidhey/whatsgoingon/test.txt',
         dir + '/fixtures/test.coffee',
         dir + '/fixtures/whatsgoingon/test.js',
-        os.tmpdir() + '/glob-stream-*.txt',
+        tmp + '/glob-stream-*.txt',
       ];
 
       console.log(paths);

--- a/test/index.js
+++ b/test/index.js
@@ -405,6 +405,8 @@ function suite(moduleName) {
         os.tmpdir() + '/glob-stream-*.txt',
       ];
 
+      console.log(paths);
+
       function assert(pathObjs) {
         fs.unlinkSync(testFile, "test");
         expect(pathObjs.length).toEqual(4);
@@ -440,7 +442,7 @@ function suite(moduleName) {
     // https://github.com/gulpjs/glob-stream/issues/129
     it('does not take a long time when when checking a singular glob in the project root', function (done) {
       // Extremely short timeout to ensure we aren't traversing node_modules
-      this.timeout(10);
+      this.timeout(20);
 
       var expected = {
         cwd: cwd,


### PR DESCRIPTION
This PR changes the walking logic to take into account the base of each glob instead of walking only the `cwd`. This allows globs that use an absolute path outside of the `cwd` or move gulpfiles into different directories (which causes the `process.cwd()` to be changed). We also need to only check the existence of a file against a singular glob. Both of these changes drastically speed up many cases of globbing.

Fixes #127
Fixes #129 
Fixes #130

I still need to look into #128 because the issue isn't clear on what paths don't work, as the only error seems to indicate an absolute path outside of the cwd.