### PR TITLE
fix: Avoid blowing the call stack when processing many files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,6 @@ typings/
 
 # Test results
 test.xunit
+
+# Massive, generated directory
+test/fixtures/too-many/

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "is-glob": "^4.0.3",
     "is-negated-glob": "^1.0.0",
     "normalize-path": "^3.0.0",
-    "now-and-later": "^3.0.0",
     "streamx": "^2.12.5"
   },
   "devDependencies": {


### PR DESCRIPTION
I've removed `now-and-later` to instead push a `resolve` action into the queue that processes symlinks.

Fixes #125
